### PR TITLE
Added --tekton flag to oc sync for credentials

### DIFF
--- a/src/pages/developer-intermediate/deploy-app/index.mdx
+++ b/src/pages/developer-intermediate/deploy-app/index.mdx
@@ -145,7 +145,7 @@ namespace into the development namespace/project. This enables the pipelines to 
 project.
 
 ```shell
-oc sync ${DEV_NAMESPACE}
+oc sync ${DEV_NAMESPACE} --tekton
 ```
 
 ### 3. Open the Developer Dashboard


### PR DESCRIPTION
Tekton pipeline fails to execute because it doesn't have credentials to create pods, need to run `oc sync $PROJECT --tekton` to have it work